### PR TITLE
Add hrefs to hx-get anchors

### DIFF
--- a/raptorWeb/templates/authprofiles/profile_dropdown_auth.html
+++ b/raptorWeb/templates/authprofiles/profile_dropdown_auth.html
@@ -36,6 +36,7 @@
         <hr style="color: white">
         <div>
             <a class="dropdown-item text-white mt-0 pt-0 htmxLink"
+               href="/{{user_path}}/{{user.get_username|slugify}}"
                hx-get="/raptormc/api/html/{{user_path}}/{{user.get_username|slugify}}"
                hx-target='#home'
                hx-push-url='/{{user_path}}/{{user.get_username|slugify}}'

--- a/raptorWeb/templates/authprofiles/raptoruser_list.html
+++ b/raptorWeb/templates/authprofiles/raptoruser_list.html
@@ -45,6 +45,7 @@
         {% for raptoruser in page_obj %}
         <div class="col-md-4 col-12">
             <a class="htmxLink"
+                href="/{{base_user_url}}/{{raptoruser.username|slugify}}"
                 hx-get="raptormc/api/html/{{base_user_url}}/{{raptoruser.username|slugify}}"
                 hx-target='#home'
                 hx-swap='innerHTML'

--- a/raptorWeb/templates/gameservers/server_list_modals.html
+++ b/raptorWeb/templates/gameservers/server_list_modals.html
@@ -46,6 +46,7 @@
 
         {% if default_pages.announcements %}
         <a role="button" class="btn btn-outline-secondary"
+           href="/announcements"
            hx-get="{% url 'raptormc:announcements' %}"
            hx-target='#home'
            hx-push-url="/announcements"
@@ -58,6 +59,7 @@
         
         {% if default_pages.rules %}
           <a role="button" class="btn btn-outline-secondary"
+             href="/rules"
              hx-get="{% url 'raptormc:rules' %}"
              hx-target='#home'
              hx-push-url="/rules"
@@ -70,6 +72,7 @@
 
         {% if default_pages.banned_items %}
           <a role="button" class="btn btn-outline-secondary"
+             href="/banneditems"
              hx-get="{% url 'raptormc:banneditems' %}"
              hx-target='#home'
              hx-push-url="/banneditems"
@@ -82,6 +85,7 @@
 
         {% if default_pages.voting %}
           <a role="button" class="btn btn-outline-secondary"
+             href='/voting'
              hx-get="{% url 'raptormc:voting' %}"
              hx-target='#home'
              hx-push-url="/voting"

--- a/raptorWeb/templates/panel/panel_sidebar.html
+++ b/raptorWeb/templates/panel/panel_sidebar.html
@@ -21,6 +21,7 @@
                 </li>
                 <li class="nav-item">
                     <a class="nav-link"
+                       href="/panel/"
                        hx-get="{% url 'panel:home' %}"
                        hx-target='#panel_main'
                        hx-push-url="/panel/home/"
@@ -32,6 +33,7 @@
                 {% if perms.raptormc.discord_bot %}
                 <li class="nav-item">
                     <a class="nav-link"
+                       href="/panel/discordbot"
                        hx-get="{% url 'panel:discordbot' %}"
                        hx-target='#panel_main'
                        hx-push-url="/panel/discordbot/"
@@ -44,6 +46,7 @@
                 {% if perms.raptormc.server_actions %}
                 <li class="nav-item">
                     <a class="nav-link"
+                       href="/panel/serveractions"
                        hx-get="{% url 'panel:serveractions' %}"
                        hx-target='#panel_main'
                        hx-push-url="/panel/serveractions/"
@@ -56,6 +59,7 @@
                 {% if perms.raptormc.reporting %}
                 <li class="nav-item">
                     <a class="nav-link"
+                       href="/panel/reporting"
                        hx-get="{% url 'panel:reporting' %}"
                        hx-target='#panel_main'
                        hx-push-url="/panel/reporting/"
@@ -68,6 +72,7 @@
                 {% if perms.raptormc.settings %}
                 <li class="nav-item">
                     <a class="nav-link"
+                       href="/panel/settings"
                        hx-get="{% url 'panel:settings' %}"
                        hx-target='#panel_main'
                        hx-push-url="/panel/settings/"

--- a/raptorWeb/templates/raptormc/navigation/lowernav.html
+++ b/raptorWeb/templates/raptormc/navigation/lowernav.html
@@ -13,6 +13,7 @@
                         <span class="navbar-toggler-icon" ></span>
                     </button>
                     <a id="navBrand" class="navbar-brand m-0 ms-3 htmxLink"
+                       href="/"
                        hx-get={% url 'raptormc:home'%}
                        hx-target='#home'
                        hx-push-url="/"

--- a/raptorWeb/templates/raptormc/navigation/navwidgets.html
+++ b/raptorWeb/templates/raptormc/navigation/navwidgets.html
@@ -19,7 +19,15 @@
           <a class="col-3 col-sm-2 col-lg-1 btn btn-outline-secondary" role="button"
              data-bs-toggle="tooltip"
              data-bs-title="{{widget.tooltip|safe}}"
-             href="{% if widget.linked_page %}{{widget.linked_page.get_absolute_url}}{% else %}{{widget.url}}{% endif %}" 
+             {% if widget.linked_page %}
+             hx-get="/raptormc/api/html{{widget.linked_page.get_absolute_url}}"
+             hx-target='#home'
+             hx-push-url="{{widget.linked_page.get_absolute_url}}"
+             hx-indicator="#mainLoadingspinner,.loaded-content"
+             href="{{widget.linked_page.get_absolute_url}}"
+             {% else %}
+             href="{{widget.url}}"
+             {% endif %}
              {% if widget.new_tab%}
              target="_blank"
           >  {% else %}
@@ -51,7 +59,15 @@
           <a class="col-3 col-sm-2 col-lg-1 btn btn-outline-secondary" role="button"
              data-bs-toggle="tooltip"
              data-bs-title="{{widget.tooltip|safe}}"
-             href="{% if widget.linked_page %}{{widget.linked_page.get_absolute_url}}{% else %}{{widget.url}}{% endif %}" 
+             {% if widget.linked_page %}
+             hx-get="/raptormc/api/html{{widget.linked_page.get_absolute_url}}"
+             hx-target='#home'
+             hx-push-url="{{widget.linked_page.get_absolute_url}}"
+             hx-indicator="#mainLoadingspinner,.loaded-content"
+             href="{{widget.linked_page.get_absolute_url}}"
+             {% else %}
+             href="{{widget.url}}"
+             {% endif %}
              {% if widget.new_tab%}
              target="_blank"
           > {%else%}

--- a/raptorWeb/templates/raptormc/navigation/offcanvasnav.html
+++ b/raptorWeb/templates/raptormc/navigation/offcanvasnav.html
@@ -12,6 +12,7 @@
 
           {% if default_pages.announcements %}<li class="btn btn-secondary m-2 p-2"> 
             <a class="nav-link text-white text-nowrap fs-5"
+               href="/announcements"
                hx-get="{% url 'raptormc:announcements' %}"
                hx-target='#home'
                hx-push-url="/announcements"
@@ -24,6 +25,7 @@
           
           {% if default_pages.rules %}<li class="btn btn-secondary m-2 p-2"> 
             <a class="nav-link text-white text-nowrap fs-5"
+               href="/rules"
                hx-get="{% url 'raptormc:rules' %}"
                hx-target='#home'
                hx-push-url="/rules"
@@ -36,6 +38,7 @@
 
           {% if default_pages.banned_items %}<li class="btn btn-secondary m-2 p-2">
             <a class="nav-link text-white text-nowrap fs-5"
+               href="/banneditems"
                hx-get="{% url 'raptormc:banneditems' %}"
                hx-target='#home'
                hx-push-url="/banneditems"
@@ -48,6 +51,7 @@
 
           {% if default_pages.voting %}<li class="btn btn-secondary m-2 p-2">
             <a class="nav-link text-white text-nowrap fs-5"
+               href="/voting"
                hx-get="{% url 'raptormc:voting' %}"
                hx-target='#home'
                hx-push-url="/voting"
@@ -60,6 +64,7 @@
 
           {% if default_pages.joining %}<li class="btn btn-secondary m-2 p-2">
             <a class="nav-link text-white text-nowrap fs-5"
+               href="/howtojoin"
                hx-get="{% url 'raptormc:howtojoin' %}"
                hx-target='#home'
                hx-push-url="/howtojoin"
@@ -72,6 +77,7 @@
           
           {% if default_pages.staff_apps %}<li class="btn btn-secondary m-2 p-2">
             <a class="nav-link text-white text-nowrap fs-5"
+               href="/applications"
                hx-get="{% url 'raptormc:applications' %}"
                hx-target='#home'
                hx-push-url="/applications"
@@ -84,6 +90,7 @@
 
           {% if default_pages.members %}<li class="btn btn-secondary m-2 p-2">
             <a class="nav-link text-white text-nowrap fs-5"
+               href="/user"
                hx-get="{% url 'raptormc:user' %}"
                hx-target='#home'
                hx-push-url="/user"
@@ -99,6 +106,7 @@
           <li class="btn btn-secondary m-2 p-2">
             <a class="nav-link text-white text-nowrap fs-5" 
                {% if link.linked_page %}
+               href="{{ link.get_linked_page_url }}"
                hx-get="/raptormc/api/html{{ link.get_linked_page_url }}"
                onclick='closeOffCanvas()'
                {% else %}
@@ -130,6 +138,7 @@
               <li>
                 <a class="dropdown-item text-white"
                    {% if nested_link.linked_page %}
+                   href="{{ nested_link.get_linked_page_url }}"
                    hx-get="/raptormc/api/html{{ nested_link.get_linked_page_url }}"
                    onclick='closeOffCanvas()'
                    {% else %}


### PR DESCRIPTION
hx-get will always take precedence with a left click, loading the page with ajax as expected. Adding the href to the anchor allows you to also open the link in a new tab with the given anchor, only if you middle-click or right-click > open in new tab.

This operates exactly how I would like now. All links on the main site have had an href added to it, derived in a similar way as the hx-get without the api url parameters.