### PR TITLE
Use multi-part form encoding and use files in view

### DIFF
--- a/raptorWeb/panel/views.py
+++ b/raptorWeb/panel/views.py
@@ -211,7 +211,10 @@ class SettingsPanelFilePost(PanelApiBaseView):
         if not request.user.has_perm('raptormc.settings'):
             return HttpResponseRedirect('/')
         
-        settings_files_form: PanelSettingsFiles = PanelSettingsFiles(request.POST)
+        settings_files_form: PanelSettingsFiles = PanelSettingsFiles(
+            data=request.POST,
+            files=request.FILES
+        )
         dictionary: dict = {"SettingsInformationFiles": settings_files_form}
         site_info = SiteInformation.objects.get_or_create(pk=1)[0]
 
@@ -273,13 +276,14 @@ class SettingsPanelDefaultPagesPost(PanelApiBaseView):
             
             for field in default_pages._meta.fields:
                 field_string = str(field).replace('raptormc.DefaultPages.', '')
-                if getattr(default_pages, field_string) != default_pages.cleaned_data[field_string]:
-                    setattr(
-                        default_pages,
-                        field_string,
-                        default_pages.cleaned_data[field_string]
-                    )
-                    changed.append(field_string.title())
+                if field_string not in SETTINGS_FIELDS_TO_IGNORE:
+                    if getattr(default_pages, field_string) != default_pages_form.cleaned_data[field_string]:
+                        setattr(
+                            default_pages,
+                            field_string,
+                            default_pages_form.cleaned_data[field_string]
+                        )
+                        changed.append(field_string.title())
                 
             for change in changed:
                 changed_string += f'{change}, '

--- a/raptorWeb/templates/panel/panel_settings.html
+++ b/raptorWeb/templates/panel/panel_settings.html
@@ -10,6 +10,7 @@
         </div>
     </div>
     <form class="form"
+          enctype="multipart/form-data" 
           hx-post="{% url 'panel:settings'%}"
           hx-swap='none'
     >
@@ -138,6 +139,7 @@
                 <div class="d-flex justify-content-center">
                     <div class="w-50">
                         <form class="form"
+                            enctype="multipart/form-data" 
                             hx-post="{% url 'panel:settings_files_update'%}"
                             hx-swap='none'
                         > 
@@ -188,6 +190,7 @@
                 <div class="d-flex justify-content-center">
                     <div class="w-50">
                         <form class="form"
+                            enctype="multipart/form-data" 
                             hx-post="{% url 'panel:settings_default_pages'%}"
                             hx-swap='none'
                         > 


### PR DESCRIPTION
This was broken. Also needed to make sure to skip the id field of the model when iterating fields.