### PR TITLE
Get packages using PK rather than name

### DIFF
--- a/raptorWeb/donations/views.py
+++ b/raptorWeb/donations/views.py
@@ -131,7 +131,7 @@ class DonationCheckout(TemplateView):
         context =  super().get_context_data(**kwargs)
         
         site_info: SiteInformation = SiteInformation.objects.get_or_create(pk=1)[0]
-        bought_package = DonationPackage.objects.get(name=str(self.kwargs['package']))
+        bought_package = DonationPackage.objects.get(pk=str(self.kwargs['package']))
         
         context['buying_package'] = bought_package
         context['base_user_url'] = BASE_USER_URL
@@ -180,7 +180,7 @@ class DonationCheckoutRedirect(View):
             return HttpResponseRedirect('/donations/failure/invalidusername')
         
         try:
-            bought_package = DonationPackage.objects.get(name=str(self.kwargs['package']))
+            bought_package = DonationPackage.objects.get(pk=str(self.kwargs['package']))
             
         except DonationPackage.DoesNotExist:
             return HttpResponseRedirect('/')

--- a/raptorWeb/raptormc/routes.py
+++ b/raptorWeb/raptormc/routes.py
@@ -100,7 +100,7 @@ def check_route(request):
         for package in all_packages:
             current_routes.append(
                 Route(
-                    name=f'donations/checkout/{slugify(package.name)}',
+                    name=f'donations/checkout/{slugify(package.pk)}',
                     route_type="package",
                     package=package,
                 )
@@ -203,7 +203,7 @@ def check_route(request):
                 return {
                     "og_package": route.package,
                     "og_color": site_info.main_color,
-                    "og_url": f"{WEB_PROTO}://{DOMAIN_NAME}/donations/checkout{slugify(route.package.name)}",
+                    "og_url": f"{WEB_PROTO}://{DOMAIN_NAME}/donations/checkout{slugify(route.package.pk)}",
                     "og_image": f"{site_avatar_url}",
                     "og_title": f"{site_info.brand_name} | {route.package.name}",
                     "og_desc": strip_tags(route.package.package_description)

--- a/raptorWeb/templates/donations/checkout.html
+++ b/raptorWeb/templates/donations/checkout.html
@@ -14,7 +14,7 @@
                 <form class="form p-3 text-white"
                     enctype="multipart/form-data"
                     method='post'
-                    action="{% url "donations:stripe_redirect" package=buying_package.name|slugify %}"
+                    action="{% url "donations:stripe_redirect" package=buying_package.pk %}"
                 >   
                     {% csrf_token %}
                     {% if buying_package.servers.count > 0 %}
@@ -97,7 +97,7 @@
                 <form class="form p-3 text-white"
                     enctype="multipart/form-data"
                     method='post'
-                    action="{% url "donations:stripe_redirect" package=buying_package.name|slugify %}"
+                    action="{% url "donations:stripe_redirect" package=buying_package.pk %}"
                 >     
                     {% csrf_token %}
                     {% bootstrap_field donation_details_form.minecraft_username %}

--- a/raptorWeb/templates/donations/donationpackage_list.html
+++ b/raptorWeb/templates/donations/donationpackage_list.html
@@ -76,7 +76,7 @@
         <div class="col-md-4 col-12">
             <a class="htmxLink"
                 data-bs-toggle="modal"
-                data-bs-target="#{{package.name}}Modal"
+                data-bs-target="#packageModal{{package.pk}}"
             >
                 <div id="package_box" class="card bg-light m-3 p-3 opacity-75">
                     <div id="profile_picture_box" class="mx-auto d-block">
@@ -96,7 +96,7 @@
                 </div>
             </a>
         </div>
-        <div id="{{package.name}}Modal" class="modal fade" tabindex="-1" aria-labelledby="{{package.name}} Details" aria-hidden="true">
+        <div id="packageModal{{package.pk}}" class="modal fade" tabindex="-1" aria-labelledby="{{package.name}} Details" aria-hidden="true">
             <div class="modal-dialog modal-lg">
                 <div class="modal-content bg-dark text-white">
                     <button class="btn-close btn-close-white m-3" data-bs-dismiss="modal" aria-label="Close"></button>

--- a/raptorWeb/templates/donations/donationpackage_list.html
+++ b/raptorWeb/templates/donations/donationpackage_list.html
@@ -117,10 +117,10 @@
                     <div class="modal-footer justify-content-center">
 
                         <a role="button" class="btn btn-outline-success"
-                        href="/donations/checkout/{{package.name|slugify}}"
-                        hx-get="{% url 'donations:checkout' package=package.name|slugify %}"
+                        href="/donations/checkout/{{package.pk}}"
+                        hx-get="{% url 'donations:checkout' package=package.pk %}"
                         hx-target='#home'
-                        hx-push-url="/donations/checkout/{{package.name|slugify}}"
+                        hx-push-url="/donations/checkout/{{package.pk}}"
                         hx-indicator="#mainLoadingspinner,.loaded-content"
                         onclick='closeModal()'
                         >


### PR DESCRIPTION
This is addressing https://github.com/zediious/raptor-web/issues/156

We will now use the package primary key for looking up the package used. The only user facing change here is that the package checkout URLS use the PK rather than the name.

This is done for the purpose of allowing spaces and special characters in package names. It also needs to be done for packages such as "VIP" and "VIP+", where the "+" is not a valid URL character. Since they both would have the same URL with this stripped, PK allows more flexibility here. It _is_ less pretty.