### PR TITLE
Create totp media directory on first run

### DIFF
--- a/raptorWeb/authprofiles/tokens.py
+++ b/raptorWeb/authprofiles/tokens.py
@@ -1,5 +1,6 @@
 from six import text_type
-from os.path import join
+from os.path import join, exists
+from os import getenv, makedirs
 from qrcode import make
 import qrcode.image.svg
 from tempfile import NamedTemporaryFile
@@ -47,6 +48,9 @@ def generate_totp_token(user: AbstractUser) -> str:
     """
     site_info: SiteInformation = SiteInformation.objects.get_or_create(pk=1)[0]
     user.totp_token = bytes(random_base32(), 'utf-8')
+    
+    if not exists(QR_MEDIA_DIR):
+        makedirs(QR_MEDIA_DIR)
     
     totp = TOTP(user.totp_token)
     qr_uri = totp.provisioning_uri(

--- a/raptorWeb/authprofiles/tokens.py
+++ b/raptorWeb/authprofiles/tokens.py
@@ -1,9 +1,8 @@
 from six import text_type
 from os.path import join, exists
-from os import getenv, makedirs
+from os import makedirs
 from qrcode import make
 import qrcode.image.svg
-from tempfile import NamedTemporaryFile
 from datetime import datetime
 from logging import Logger, getLogger
 
@@ -11,7 +10,6 @@ from pyotp import random_base32, TOTP
 
 from django.conf import settings
 from django.contrib.auth.models import AbstractUser
-from django.core.files import File
 from django.contrib.auth.tokens import PasswordResetTokenGenerator
 
 from raptorWeb.raptormc.models import SiteInformation


### PR DESCRIPTION
Since the QR images are not placed there through normal means, we need to create the directory manually on the first run.