### PR TITLE
 Clear orphaned QR images

### DIFF
--- a/config/logging.py
+++ b/config/logging.py
@@ -145,6 +145,11 @@ LOGGING_DEFINITION = {
             'level': 'DEBUG',
             'propagate': False,
         },
+        'authprofiles.tasks': {
+            'handlers': ['console', 'log_file', 'mail_admins'],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
         'gameservers.views': {
             'handlers': ['console', 'log_file', 'mail_admins'],
             'level': 'DEBUG',

--- a/config/settings.py
+++ b/config/settings.py
@@ -277,6 +277,10 @@ CELERY_BEAT_SCHEDULE = {
         'task': 'raptorWeb.authprofiles.tasks.check_for_deletable_users',
         'schedule': crontab(minute='*/15'),
     },
+    'check_for_deletable_qr_images': {
+        'task': 'raptorWeb.authprofiles.tasks.check_for_deletable_qr_images',
+        'schedule': crontab(minute='*/5'),
+    }
 }
 
 # ** Settings for "django-jazzmin" app **

--- a/raptorWeb/authprofiles/tasks.py
+++ b/raptorWeb/authprofiles/tasks.py
@@ -16,7 +16,7 @@ from celery import shared_task
 from raptorWeb.authprofiles.models import RaptorUser, DeletionQueueForUser
 from raptorWeb.raptormc.models import SiteInformation
 
-LOGGER = getLogger('donations.tasks')
+LOGGER = getLogger('authprofiles.tasks')
 AUTH_TEMPLATE_DIR: str = getattr(settings, 'AUTH_TEMPLATE_DIR')
 EMAIL_HOST_USER: str = getattr(settings, 'EMAIL_HOST_USER')
 

--- a/raptorWeb/authprofiles/tokens.py
+++ b/raptorWeb/authprofiles/tokens.py
@@ -57,7 +57,6 @@ def generate_totp_token(user: AbstractUser) -> str:
     )
     
     qr_filename =  f'{QR_MEDIA_DIR}{hash(datetime.now())}.svg'
-    LOGGER.debug(qr_filename)
 
     qr_code_image = make(
         qr_uri,


### PR DESCRIPTION
If a user does not set up MFA after generating the QR, the image will be left behind and not deleted.

This new task will check any images in the totp media folder, and delete them if they are older than 15 minutes. This task will run every 5 minutes