### PR TITLE
Add env option to determine if bot starts on app startup

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -30,6 +30,7 @@ DEFAULT_SUPERUSER_EMAIL=''
 
 DISCORD_BOT_TOKEN=''
 DISCORD_BOT_DESCRIPTION=''
+RUN_BOT='True'
 
 STRIPE_PUBLISHABLE_KEY=''
 STRIPE_SECRET_KEY=''
@@ -98,6 +99,9 @@ The Bot Token for the Discord Application Bot you will use for the Discord Bot
 
 ### **DISCORD_BOT_DESCRIPTION**
 A description for the Discord Bot, used when creating the Bot
+
+### **RUN_BOT**
+Whether the Discord Bot will run on application startup. This may need to be set to false when updating the application. The bot can always be started after the application starts from the Discord Bot Panel.
 
 # *Stripe Payments*
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -257,6 +257,7 @@ DISCORD_AUTH_URL: str = ("https://discord.com/api/oauth2/authorize?"
 # ** Settings for "raptorbot" app **
 DISCORD_BOT_TOKEN: str = getenv('DISCORD_BOT_TOKEN')
 DISCORD_BOT_DESCRIPTION: str = getenv('DISCORD_BOT_DESCRIPTION')
+RUN_BOT: bool = True if getenv('RUN_BOT') == 'True' or 'true' else False
 
 # ** Celery Settings **
 CELERY_BEAT_SCHEDULE = {

--- a/raptorWeb/raptorbot/botware.py
+++ b/raptorWeb/raptorbot/botware.py
@@ -7,6 +7,7 @@ from raptorWeb.raptorbot.discordbot.bot import BotProcessManager
 from raptorWeb.raptorbot.models import DiscordBotTasks, DiscordBotInternal
 
 DISCORD_BOT_TOKEN: str = getattr(settings, 'DISCORD_BOT_TOKEN')
+RUN_BOT: bool = getattr(settings, 'RUN_BOT')
 LOGGER: Logger = getLogger('raptorbot.botware')
 
 bot_process_manager: BotProcessManager = BotProcessManager(bot_token=DISCORD_BOT_TOKEN)
@@ -21,7 +22,8 @@ class RaptorBotWare:
         One-time configuration and initialization.
         """
         self.get_response = get_response
-        start_bot_process()
+        if RUN_BOT:
+            start_bot_process()
 
     def __call__(self, request):
         """


### PR DESCRIPTION
The discord bot attempts to make queries to siteinformation before migrations occur, causing errors if new fields are added.

This option allows you to stop the bot from starting on app startup, to allow migrations to occur.