### PR TITLE
Do not swap when adding in create views

### DIFF
--- a/raptorWeb/templates/panel/crud/createdstaffapplication_create.html
+++ b/raptorWeb/templates/panel/crud/createdstaffapplication_create.html
@@ -22,8 +22,7 @@
         enctype="multipart/form-data" 
         hx-post="{% url 'panel:staffapps/createdstaffapplication/create' %} "
         hx-push-url='/panel/staffapps/createdstaffapplication/list'
-        hx-target='#panel_main'
-        hx-swap="innerHTML"
+        hx-swap="none"
     >
         {% csrf_token %}
         {% bootstrap_form form %}

--- a/raptorWeb/templates/panel/crud/donationdiscordrole_create.html
+++ b/raptorWeb/templates/panel/crud/donationdiscordrole_create.html
@@ -22,8 +22,7 @@
         enctype="multipart/form-data" 
         hx-post="{% url 'panel:donations/donationdiscordrole/create' %} "
         hx-push-url='/panel/donations/donationdiscordrole/list'
-        hx-target='#panel_main'
-        hx-swap="innerHTML"
+        hx-swap="none"
     >
         {% csrf_token %}
         {% bootstrap_form form %}

--- a/raptorWeb/templates/panel/crud/donationpackage_create.html
+++ b/raptorWeb/templates/panel/crud/donationpackage_create.html
@@ -20,8 +20,7 @@
         enctype="multipart/form-data" 
         hx-post="{% url 'panel:donations/donationpackage/create' %} "
         hx-push-url='/panel/donations/donationpackage/list'
-        hx-target='#panel_main'
-        hx-swap="innerHTML"
+        hx-swap="none"
     >
         {% csrf_token %}
         {% bootstrap_form form %}

--- a/raptorWeb/templates/panel/crud/donationservercommand_create.html
+++ b/raptorWeb/templates/panel/crud/donationservercommand_create.html
@@ -22,8 +22,7 @@
         enctype="multipart/form-data" 
         hx-post="{% url 'panel:donations/donationservercommand/create' %} "
         hx-push-url='/panel/donations/donationservercommand/list'
-        hx-target='#panel_main'
-        hx-swap="innerHTML"
+        hx-swap="none"
     >
         {% csrf_token %}
         {% bootstrap_form form %}

--- a/raptorWeb/templates/panel/crud/navbardropdown_create.html
+++ b/raptorWeb/templates/panel/crud/navbardropdown_create.html
@@ -22,8 +22,7 @@
         enctype="multipart/form-data" 
         hx-post="{% url 'panel:content/navbardropdown/create' %} "
         hx-push-url='/panel/content/navbardropdown/list'
-        hx-target='#panel_main'
-        hx-swap="innerHTML"
+        hx-swap="none"
     >
         {% csrf_token %}
         {% bootstrap_form form %}

--- a/raptorWeb/templates/panel/crud/navbarlink_create.html
+++ b/raptorWeb/templates/panel/crud/navbarlink_create.html
@@ -22,8 +22,7 @@
         enctype="multipart/form-data" 
         hx-post="{% url 'panel:content/navbarlink/create' %} "
         hx-push-url='/panel/content/navbarlink/list'
-        hx-target='#panel_main'
-        hx-swap="innerHTML"
+        hx-swap="none"
     >
         {% csrf_token %}
         {% bootstrap_form form %}

--- a/raptorWeb/templates/panel/crud/navwidget_create.html
+++ b/raptorWeb/templates/panel/crud/navwidget_create.html
@@ -22,8 +22,7 @@
         enctype="multipart/form-data" 
         hx-post="{% url 'panel:content/navwidget/create' %} "
         hx-push-url='/panel/content/navwidget/list'
-        hx-target='#panel_main'
-        hx-swap="innerHTML"
+        hx-swap="none"
     >
         {% csrf_token %}
         {% bootstrap_form form %}

--- a/raptorWeb/templates/panel/crud/navwidgetbar_create.html
+++ b/raptorWeb/templates/panel/crud/navwidgetbar_create.html
@@ -22,8 +22,7 @@
         enctype="multipart/form-data" 
         hx-post="{% url 'panel:content/navwidgetbar/create' %} "
         hx-push-url='/panel/content/navwidgetbar/list'
-        hx-target='#panel_main'
-        hx-swap="innerHTML"
+        hx-swap="none"
     >
         {% csrf_token %}
         {% bootstrap_form form %}

--- a/raptorWeb/templates/panel/crud/page_create.html
+++ b/raptorWeb/templates/panel/crud/page_create.html
@@ -20,8 +20,7 @@
         enctype="multipart/form-data" 
         hx-post="{% url 'panel:content/page/create' %} "
         hx-push-url='/panel/content/page/list'
-        hx-target='#panel_main'
-        hx-swap="innerHTML"
+        hx-swap="none"
     >
         {% csrf_token %}
         {% bootstrap_form form %}

--- a/raptorWeb/templates/panel/crud/raptorusergroup_create.html
+++ b/raptorWeb/templates/panel/crud/raptorusergroup_create.html
@@ -22,8 +22,7 @@
         enctype="multipart/form-data" 
         hx-post="{% url 'panel:users/raptorusergroup/create' %} "
         hx-push-url='/panel/users/raptorusergroup/list'
-        hx-target='#panel_main'
-        hx-swap="innerHTML"
+        hx-swap="none"
     >
         {% csrf_token %}
         {% bootstrap_form form %}

--- a/raptorWeb/templates/panel/crud/server_create.html
+++ b/raptorWeb/templates/panel/crud/server_create.html
@@ -21,8 +21,7 @@
         enctype="multipart/form-data" 
         hx-post="{% url 'panel:server/create' %} "
         hx-push-url='/panel/server/list/'
-        hx-target='#panel_main'
-        hx-swap="innerHTML"
+        hx-swap="none"
     >
         {% csrf_token %}
         {% bootstrap_form form %}

--- a/raptorWeb/templates/panel/crud/staffapplicationfield_create.html
+++ b/raptorWeb/templates/panel/crud/staffapplicationfield_create.html
@@ -22,8 +22,7 @@
         enctype="multipart/form-data" 
         hx-post="{% url 'panel:staffapps/staffapplicationfield/create' %} "
         hx-push-url='/panel/staffapps/staffapplicationfield/list'
-        hx-target='#panel_main'
-        hx-swap="innerHTML"
+        hx-swap="none"
     >
         {% csrf_token %}
         {% bootstrap_form form %}


### PR DESCRIPTION
If form validation fails, the entire page is swapped to a blank page. When it is valid, a redirect is issued back to the list

Chang the hx-swap attribute to not swap at all, so that if the validation fails, the error message is displayed and can be corrected/resubmitted