### PR TITLE
Scroll near accordion when using server modal buttons to navigate

### DIFF
--- a/raptorWeb/templates/gameservers/server_list_announcements.html
+++ b/raptorWeb/templates/gameservers/server_list_announcements.html
@@ -1,5 +1,5 @@
 {% for server in object_list %}
-<div class="accordion-item">
+<div id="serverAccordion{{server.pk}}" class="accordion-item">
     <h2 class="accordion-header" id="{{ server.pk }}Announcements">
         <a id="{{ server.pk }}"></a>
         <div class="d-flex">

--- a/raptorWeb/templates/gameservers/server_list_banneditems.html
+++ b/raptorWeb/templates/gameservers/server_list_banneditems.html
@@ -1,5 +1,5 @@
 {% for server in object_list %}
-<div class="accordion-item">
+<div id="serverAccordion{{server.pk}}" class="accordion-item">
     <h2 class="accordion-header" id="{{ server.pk }}BannedItems">
         <a id="{{ server.pk }}"></a>
         <button class="accordion-button collapsed pageHeader text-center"

--- a/raptorWeb/templates/gameservers/server_list_modals.html
+++ b/raptorWeb/templates/gameservers/server_list_modals.html
@@ -49,6 +49,7 @@
            href="/announcements?server={{server.pk}}"
            hx-get="{% url 'raptormc:announcements' %}?server={{server.pk}}"
            hx-target='#home'
+           hx-swap = "innerHTML show:body:bottom settle:50ms"
            hx-push-url="/announcements"
            hx-indicator="#mainLoadingspinner,.loaded-content"
            onclick='closeModal()'
@@ -62,6 +63,7 @@
              href="/rules?server={{server.pk}}"
              hx-get="{% url 'raptormc:rules' %}?server={{server.pk}}"
              hx-target='#home'
+             hx-swap = "innerHTML show:body:bottom settle:50ms"
              hx-push-url="/rules"
              hx-indicator="#mainLoadingspinner,.loaded-content"
              onclick='closeModal()'
@@ -75,6 +77,7 @@
              href="/banneditems?server={{server.pk}}"
              hx-get="{% url 'raptormc:banneditems' %}?server={{server.pk}}"
              hx-target='#home'
+             hx-swap = "innerHTML show:body:bottom settle:50ms"
              hx-push-url="/banneditems"
              hx-indicator="#mainLoadingspinner,.loaded-content"
              onclick='closeModal()'
@@ -88,6 +91,7 @@
              href='/voting?server={{server.pk}}'
              hx-get="{% url 'raptormc:voting' %}?server={{server.pk}}"
              hx-target='#home'
+             hx-swap = "innerHTML show:body:bottom settle:50ms"
              hx-push-url="/voting"
              hx-indicator="#mainLoadingspinner,.loaded-content"
              onclick='closeModal()'

--- a/raptorWeb/templates/gameservers/server_list_rules.html
+++ b/raptorWeb/templates/gameservers/server_list_rules.html
@@ -1,5 +1,5 @@
 {% for server in object_list %}
-  <div class="accordion-item">
+  <div id="serverAccordion{{server.pk}}" class="accordion-item">
     <h2 class="accordion-header" id="{{ server.pk }}Rules">
       <a id="{{ server.pk }}"></a>
       <button class="accordion-button collapsed pageHeader text-center"

--- a/raptorWeb/templates/gameservers/server_list_voting.html
+++ b/raptorWeb/templates/gameservers/server_list_voting.html
@@ -1,5 +1,5 @@
 {% for server in object_list %}
-<div class="accordion-item">
+<div id="serverAccordion{{server.pk}}" class="accordion-item">
     <h2 class="accordion-header" id="{{ server.pk }}Voting">
     <a id="{{ server.pk }}"></a>
     <button class="accordion-button collapsed pageHeader text-center"


### PR DESCRIPTION
When using rules, banned items, announcements, or voting buttons in a server modal, scroll near the accordion element a few milliseconds after clicking.