### PR TITLE
flex align items center on server button images

### DIFF
--- a/raptorWeb/templates/gameservers/server_list.html
+++ b/raptorWeb/templates/gameservers/server_list.html
@@ -51,7 +51,7 @@
                             
             {% if server_query_enabled %}
             <div class="fade-in-button col-lg-12 col-6 mt-1">
-                <button class="btn btn-dark fs-4 d-flex mt-2 w-100"
+                <button class="btn btn-dark fs-4 d-flex align-items-center mt-2 w-100"
                         data-bs-toggle="modal"
                         data-bs-target="#modal_{{ server.pk }}_Info"
                 >


### PR DESCRIPTION
Firefox stretches to height, chromium pushes to the top. Define center so both browsers behave the same