### PR TITLE
Do not attempt to update user slug if user does not exist

### DIFF
--- a/raptorWeb/authprofiles/models.py
+++ b/raptorWeb/authprofiles/models.py
@@ -522,6 +522,11 @@ def pre_save_raptor_user(sender, instance, *args, **kwargs):
     If a Raptoruser's Username is changed, update their User Slug to a slufigied
     version of the new username
     """
-    if instance.username != RaptorUser.objects.get(pk=instance.pk).username:
-        instance.user_slug = slugify(instance.username)
-        
+    
+    try:
+        changed_user = RaptorUser.objects.get(pk=instance.pk)
+        if instance.username != changed_user.username:
+            instance.user_slug = slugify(instance.username)
+            
+    except RaptorUser.DoesNotExist:
+        pass     


### PR DESCRIPTION
This pre_save is called when users are registerd, causing an error as the user does not exist.

Check that the user exists before attempting to save.