### PR TITLE
Properly call aupdate on queryset

### DIFF
--- a/raptorWeb/raptorbot/discordbot/util/presence.py
+++ b/raptorWeb/raptorbot/discordbot/util/presence.py
@@ -58,7 +58,7 @@ async def update_member_count(bot_instance: commands.Bot) -> None:
             online_members += 1
     
     try:
-        await DiscordGuild.objects.afirst().aupdate(
+        await DiscordGuild.objects.filter(guild_id=server.id).aupdate(
             total_members = member_total,
             online_members = online_members,
             guild_name = server.name,


### PR DESCRIPTION
afirst() returns the model.

This fixes guild member counts never updating.