### PR TITLE
Hxrequest middleware handler

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -96,7 +96,8 @@ MIDDLEWARE: list[str] = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'raptorWeb.raptorbot.botware.RaptorBotWare',
-    'raptorWeb.panel.middleware.PanelMessages'
+    'raptorWeb.panel.middleware.PanelMessages',
+    'raptorWeb.raptormc.hx_reroute_middleware.HxReroute'
 ]
 
 ROOT_URLCONF: str = 'config.urls'

--- a/raptorWeb/donations/views.py
+++ b/raptorWeb/donations/views.py
@@ -39,11 +39,7 @@ class CompletedDonationsPublic(ListView):
         if not DefaultPages.objects.get_or_create(pk=1)[0].donations:
             return HttpResponseRedirect('/404')
         
-        if request.headers.get('HX-Request') == "true":
-            return super().get(request, *args, **kwargs)
-
-        else:
-            return HttpResponseRedirect('/')
+        return super().get(request, *args, **kwargs)
         
     def get_queryset(self) -> QuerySet[Any]:
         return CompletedDonation.objects.all().order_by('-donation_datetime')[:5]
@@ -63,11 +59,7 @@ class DonationPackages(ListView):
         if not DefaultPages.objects.get_or_create(pk=1)[0].donations:
             return HttpResponseRedirect('/404')
         
-        if request.headers.get('HX-Request') == "true":
-            return super().get(request, *args, **kwargs)
-
-        else:
-            return HttpResponseRedirect('/')
+        return super().get(request, *args, **kwargs)
         
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
@@ -97,11 +89,7 @@ class DonationCheckout(TemplateView):
         if not DefaultPages.objects.get_or_create(pk=1)[0].donations:
             return HttpResponseRedirect('/404')
         
-        if request.headers.get('HX-Request') == "true":
-            return super().get(request, *args, **kwargs)
-
-        else:
-            return HttpResponseRedirect('/')
+        return super().get(request, *args, **kwargs)
         
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
         context =  super().get_context_data(**kwargs)

--- a/raptorWeb/gameservers/views.py
+++ b/raptorWeb/gameservers/views.py
@@ -31,13 +31,6 @@ class Server_List_Base(ListView):
             return Server.objects.get_servers()
         
         return Server.objects.get_servers(wait=False)
-
-    def get(self, request: HttpRequest, *args: tuple, **kwargs: dict) -> HttpResponse:
-        if request.headers.get('HX-Request') == "true":
-            return super().get(request, *args, **kwargs)
-
-        else:
-            return HttpResponseRedirect('/')
         
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -81,12 +74,8 @@ class Player_List(ListView):
         return context
 
     def get(self, request, *args, **kwargs):
-        if request.headers.get('HX-Request') == "true":
-            Server.objects.update_servers()
-            return super().get(request, *args, **kwargs)
-
-        else:
-            return HttpResponseRedirect('/')
+        Server.objects.update_servers()
+        return super().get(request, *args, **kwargs)
         
         
 class Server_Onboarding(DetailView):
@@ -95,13 +84,6 @@ class Server_Onboarding(DetailView):
     Contains all information regarding a server
     """
     model: Server = Server
-
-    def get(self, request: HttpRequest, *args: tuple, **kwargs: dict) -> HttpResponse:     
-        if request.headers.get('HX-Request') != "true":
-            return HttpResponseRedirect('/')
-        
-        else:
-            return super().get(request, *args, **kwargs)
 
     def get_object(self):
         for server in Server.objects.filter(archived=False):
@@ -116,9 +98,6 @@ class Server_Description(TemplateView):
     Return the server description of a requested server
     """
     def get(self, request: HttpRequest, *args: tuple, **kwargs: dict) -> HttpResponse:
-        if request.headers.get('HX-Request') != "true":
-            return HttpResponseRedirect('/')
-            
         requested_server = request.GET.get('server').replace('onboarding/', '')
         all_servers = Server.objects.filter(archived=False)
         for server in all_servers:

--- a/raptorWeb/panel/views.py
+++ b/raptorWeb/panel/views.py
@@ -70,10 +70,6 @@ class PanelApiBaseView(TemplateView):
     template_name: str
     
     def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
-        
-        if request.headers.get('HX-Request') != "true":
-            return HttpResponseRedirect('/')
-        
         if not request.user.is_staff:
             return render(request, template_name=join(TEMPLATE_DIR_PANEL, 'panel_no_access.html'))
             
@@ -143,9 +139,6 @@ class SettingsPanel(PanelApiBaseView):
         if not request.user.has_perm('raptormc.settings'):
             return render(request, template_name=join(TEMPLATE_DIR_PANEL, 'panel_no_access.html'))
         
-        if request.headers.get('HX-Request') != "true":
-            return HttpResponseRedirect('/')
-        
         site_info = SiteInformation.objects.get_or_create(pk=1)[0]
         site_data = {}
         for field in site_info._meta.fields:
@@ -172,9 +165,6 @@ class SettingsPanel(PanelApiBaseView):
         })
         
     def post(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
-        if request.headers.get('HX-Request') != "true":
-            return HttpResponseRedirect('/')
-        
         if not request.user.is_staff:
             return HttpResponseRedirect('/')
         
@@ -240,9 +230,6 @@ class SettingsPanelFilePost(PanelApiBaseView):
     Endpoint to submit files in the control panel
     """      
     def post(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
-        if request.headers.get('HX-Request') != "true":
-            return HttpResponseRedirect('/')
-        
         if not request.user.is_staff:
             return HttpResponseRedirect('/')
         
@@ -321,9 +308,6 @@ class SettingsPanelDefaultPagesPost(PanelApiBaseView):
     Endpoint to submit boolean data about whether default pages are enabled
     """      
     def post(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
-        if request.headers.get('HX-Request') != "true":
-            return HttpResponseRedirect('/')
-        
         if not request.user.is_staff:
             return HttpResponseRedirect('/')
         
@@ -399,15 +383,11 @@ class PanelUpdateView(UpdateView):
         if not request.user.has_perm(self.permission):
             return render(request, template_name=join(TEMPLATE_DIR_PANEL, 'panel_no_access.html'))
         
-        if request.headers.get('HX-Request') != "true":
-            return HttpResponseRedirect('/')
+        
         
         return super().get(request, *args, **kwargs)
 
     def post(self, request: HttpRequest, *args: str, **kwargs: Any) -> HttpResponse:
-        if request.headers.get('HX-Request') != "true":
-            return HttpResponseRedirect('/')
-        
         if not request.user.has_perm(self.permission):
             return render(request, template_name=join(TEMPLATE_DIR_PANEL, 'panel_no_access.html'))
         
@@ -506,9 +486,6 @@ class PanelListView(ListView):
     model_name: str = ''
     
     def get(self, request: HttpRequest, *args: tuple, **kwargs: dict) -> HttpResponse:
-        if request.headers.get('HX-Request') != "true":
-            return HttpResponseRedirect('/')
-        
         if not request.user.has_perm(self.permission):
             return render(request, template_name=join(TEMPLATE_DIR_PANEL, 'panel_no_access.html'))
         
@@ -592,9 +569,6 @@ class PanelCreateView(CreateView):
     def get(self, request: HttpRequest, *args: str, **kwargs: Any) -> HttpResponse:
         if not request.user.has_perm(self.permission):
             return render(request, template_name=join(TEMPLATE_DIR_PANEL, 'panel_no_access.html'))
-        
-        if request.headers.get('HX-Request') != "true":
-            return HttpResponseRedirect('/')
         
         return super().get(request, *args, **kwargs)
     
@@ -691,8 +665,6 @@ class PanelDetailView(DetailView):
     permission: str = ''
     
     def get(self, request: HttpRequest, *args: tuple, **kwargs: dict) -> HttpResponse:     
-        if request.headers.get('HX-Request') != "true":
-            return HttpResponseRedirect('/')
         
         if not request.user.has_perm(self.permission):
             return render(request, template_name=join(TEMPLATE_DIR_PANEL, 'panel_no_access.html'))

--- a/raptorWeb/raptorbot/views.py
+++ b/raptorWeb/raptorbot/views.py
@@ -44,11 +44,7 @@ class Global_Announcements(ListView):
         except ModuleNotFoundError:
             pass
         
-        if request.headers.get('HX-Request') == "true":
-            return super().get(request, *args, **kwargs)
-
-        else:
-            return HttpResponseRedirect('/')
+        return super().get(request, *args, **kwargs)
 
 class Server_Announcements(ListView):
         """
@@ -74,10 +70,7 @@ class Server_Announcements(ListView):
             except ModuleNotFoundError:
                 pass
             
-            if request.headers.get('HX-Request') == "true":
-                return super().get(request, *args, **kwargs)
-            else:
-                return HttpResponseRedirect('/')
+            return super().get(request, *args, **kwargs)
             
             
 class Get_Bot_Status(TemplateView):

--- a/raptorWeb/raptormc/hx_reroute_middleware.py
+++ b/raptorWeb/raptormc/hx_reroute_middleware.py
@@ -1,0 +1,14 @@
+import json
+from django.utils.deprecation import MiddlewareMixin
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
+from django.contrib.messages import get_messages
+
+class HxReroute(MiddlewareMixin):
+
+    def process_response(self, request: HttpRequest, response: HttpResponse) -> HttpResponse:
+
+        # 404 the request if HX-Request is not true
+        if ((request.headers.get('HX-Request') != "true") and ('/api/' in request.path)):
+            return HttpResponseRedirect('/404')
+
+        return response

--- a/raptorWeb/raptormc/views.py
+++ b/raptorWeb/raptormc/views.py
@@ -22,6 +22,7 @@ class BaseView(TemplateView):
     Base view for SPA
     """
     template_name: str = join(TEMPLATE_DIR_RAPTORMC, 'base.html')
+    non_htmx: bool = True
     
     def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
         route_result = check_route(request, CURRENT_URLPATTERNS, 'main')
@@ -30,20 +31,10 @@ class BaseView(TemplateView):
         
         return render(request, template_name=join(TEMPLATE_DIR_RAPTORMC, 'base.html'), context={"is_404": 'true'})
     
-class HxTemplateView(TemplateView):
-    """
-    Return 404 when "HX-Request" header is not true
-    """
-    def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
-        if request.headers.get('HX-Request') != "true":
-            return HttpResponseRedirect(request.path.replace('raptormc/api/html/', ''))
-            
-        return super().get(request, *args, **kwargs)
-    
 
-class HxDefaultPageTemplateView(HxTemplateView):
+class DefaultPageTemplateView(TemplateView):
     """
-    Return 404 when "HX-Request" header is not true
+    Take a DefaultPages attribute, return 404 if attribute is false on DefaultPages object
     """
     page_name: str = ''
 
@@ -53,7 +44,7 @@ class HxDefaultPageTemplateView(HxTemplateView):
             
         return super().get(request, *args, **kwargs)
     
-class HxInformativeTemplateView(HxTemplateView):
+class InformativeTemplateView(TemplateView):
     """
     Add list of passed informative texts to context, creating if non-existent.
     """
@@ -66,7 +57,7 @@ class HxInformativeTemplateView(HxTemplateView):
             informative_text_names=self.informative_texts)
     
 
-class HxDefaultPageInformativeTemplateView(HxDefaultPageTemplateView):
+class DefaultPageInformativeTemplateView(DefaultPageTemplateView):
     """
     Add list of passed informative texts to context, creating if non-existent.
     """
@@ -79,7 +70,7 @@ class HxDefaultPageInformativeTemplateView(HxDefaultPageTemplateView):
             informative_text_names=self.informative_texts)
 
 
-class HomeServers(HxInformativeTemplateView):
+class HomeServers(InformativeTemplateView):
     """
     Homepage with general information
     """
@@ -87,7 +78,7 @@ class HomeServers(HxInformativeTemplateView):
     informative_texts = ["Homepage Information"]
 
 
-class Announcements(HxDefaultPageInformativeTemplateView):
+class Announcements(DefaultPageInformativeTemplateView):
     """
     Page containing the last 30 announcements from Discord
     """
@@ -96,7 +87,7 @@ class Announcements(HxDefaultPageInformativeTemplateView):
     page_name = 'announcements'
 
 
-class Rules(HxDefaultPageInformativeTemplateView):
+class Rules(DefaultPageInformativeTemplateView):
     """
     Rules page containing general and server-specific rules
     """
@@ -105,7 +96,7 @@ class Rules(HxDefaultPageInformativeTemplateView):
     page_name = 'rules'
 
 
-class BannedItems(HxDefaultPageInformativeTemplateView):
+class BannedItems(DefaultPageInformativeTemplateView):
     """
     Contains lists of items that are banned on each server
     """
@@ -114,7 +105,7 @@ class BannedItems(HxDefaultPageInformativeTemplateView):
     page_name = 'banned_items'
 
 
-class Voting(HxDefaultPageInformativeTemplateView):
+class Voting(DefaultPageInformativeTemplateView):
     """
     Contains lists links for each server's voting sites
     """
@@ -123,7 +114,7 @@ class Voting(HxDefaultPageInformativeTemplateView):
     page_name = 'voting'
 
 
-class HowToJoin(HxDefaultPageInformativeTemplateView):
+class HowToJoin(DefaultPageInformativeTemplateView):
     """
     Contains guides for downloading modpacks and joining servers.
     """
@@ -137,7 +128,16 @@ class HowToJoin(HxDefaultPageInformativeTemplateView):
     page_name = 'joining'
 
 
-class StaffApps(HxDefaultPageInformativeTemplateView):
+class Onboarding(DefaultPageInformativeTemplateView):
+    """
+    Onboarding page containing all info about a specific server
+    """
+    template_name: str = join(TEMPLATE_DIR_RAPTORMC, 'defaultpages/onboarding.html')
+    informative_texts = ["Rules Information", "Network Rules"]
+    page_name = 'onboarding'
+
+
+class StaffApps(DefaultPageInformativeTemplateView):
     """
     Provide links to each staff application
     """
@@ -146,7 +146,7 @@ class StaffApps(HxDefaultPageInformativeTemplateView):
     page_name = 'staff_apps'
         
         
-class Donations(HxDefaultPageInformativeTemplateView):
+class Donations(DefaultPageInformativeTemplateView):
     """
     Donation packages list
     """
@@ -155,7 +155,7 @@ class Donations(HxDefaultPageInformativeTemplateView):
     page_name = 'donations'
         
         
-class DonationsCheckout(HxDefaultPageInformativeTemplateView):
+class DonationsCheckout(DefaultPageInformativeTemplateView):
     """
     Donation package checkout
     """
@@ -164,7 +164,7 @@ class DonationsCheckout(HxDefaultPageInformativeTemplateView):
     page_name = 'donations'
     
         
-class DonationsSuccess(HxDefaultPageInformativeTemplateView):
+class DonationsSuccess(DefaultPageInformativeTemplateView):
     """
     Donation success page
     """
@@ -173,7 +173,7 @@ class DonationsSuccess(HxDefaultPageInformativeTemplateView):
     page_name = 'donations'
     
     
-class DonationsFailure(HxDefaultPageInformativeTemplateView):
+class DonationsFailure(DefaultPageInformativeTemplateView):
     """
     Donation failure page
     """
@@ -182,7 +182,7 @@ class DonationsFailure(HxDefaultPageInformativeTemplateView):
     page_name = 'donations'
         
         
-class DonationsFailureInvalidUsername(HxDefaultPageInformativeTemplateView):
+class DonationsFailureInvalidUsername(DefaultPageInformativeTemplateView):
     """
     Donation failure page when Minecraft username is invalid
     """
@@ -191,7 +191,7 @@ class DonationsFailureInvalidUsername(HxDefaultPageInformativeTemplateView):
     page_name = 'donations'
         
         
-class DonationsFailureInvalidPrice(HxDefaultPageInformativeTemplateView):
+class DonationsFailureInvalidPrice(DefaultPageInformativeTemplateView):
     """
     Donation failure page when chosen price is below minimum
     """
@@ -200,7 +200,7 @@ class DonationsFailureInvalidPrice(HxDefaultPageInformativeTemplateView):
     page_name = 'donations'
 
     
-class DonationsAlreadyDonated(HxDefaultPageInformativeTemplateView):
+class DonationsAlreadyDonated(DefaultPageInformativeTemplateView):
     """
     Donation already made page
     """
@@ -209,7 +209,7 @@ class DonationsAlreadyDonated(HxDefaultPageInformativeTemplateView):
     page_name = 'donations'
 
 
-class SiteMembers(HxDefaultPageInformativeTemplateView):
+class SiteMembers(DefaultPageInformativeTemplateView):
     """
     Provide links to each Site Member's profile
     """
@@ -240,7 +240,7 @@ class SiteMembers(HxDefaultPageInformativeTemplateView):
             informative_text_names=["User Information"])
 
 
-class User_Page(HxTemplateView):
+class User_Page(TemplateView):
     """
     Info about a User
     """
@@ -255,7 +255,7 @@ class User_Page(HxTemplateView):
         return super().get(request, *args, **kwargs)
 
 
-class User_Pass_Reset(HxTemplateView):
+class User_Pass_Reset(TemplateView):
     """
     Page to reset user password
     """
@@ -268,15 +268,6 @@ class User_Pass_Reset(HxTemplateView):
             "active_user_password_reset_token": self.request.path.split('/')[7]
         })
         return context
-    
-    
-class Onboarding(HxDefaultPageInformativeTemplateView):
-    """
-    Onboarding page containing all info about a specific server
-    """
-    template_name: str = join(TEMPLATE_DIR_RAPTORMC, 'defaultpages/onboarding.html')
-    informative_texts = ["Rules Information", "Network Rules"]
-    page_name = 'onboarding'
 
 
 class PageView(DetailView):
@@ -284,12 +275,6 @@ class PageView(DetailView):
     Generic view for user created pages
     """
     model: Page = Page
-    
-    def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
-        if request.headers.get('HX-Request') != "true":
-            return HttpResponseRedirect('/404')
-        
-        return super().get(request, *args, **kwargs)
 
     def get_object(self):
         return Page.objects.get_slugged_page(self.kwargs['page_name'])
@@ -301,8 +286,6 @@ class Update_Headerbox_State(View):
     expansion state.
     """
     def post(self, request: HttpRequest, *args: tuple, **kwargs: dict[str, Any]) -> HttpResponse:
-        if request.headers.get('HX-Request') != "true":
-            HttpResponseRedirect('/404')
 
         try:
             if request.session['headerbox_expanded'] == 'false':
@@ -323,9 +306,6 @@ class View_404(TemplateView):
     template_name: str = join(TEMPLATE_DIR_RAPTORMC, join('404.html'))
     
     def get(self, request: HttpRequest, *args: tuple, **kwargs: dict[str, Any]) -> HttpResponse:
-        if request.headers.get('HX-Request') == "true":
-            return super().get(request, *args, **kwargs)
-        
         return render(request, template_name=join(TEMPLATE_DIR_RAPTORMC, 'base.html'), context={"is_404": 'true'})
 
 

--- a/raptorWeb/staffapps/views.py
+++ b/raptorWeb/staffapps/views.py
@@ -35,13 +35,9 @@ class AllApps(TemplateView):
         except ModuleNotFoundError:
             pass
         
-        if request.headers.get('HX-Request') == "true":
-            return render(request, self.template_name, context={
-                'created_applications': CreatedStaffApplication.objects.all()
-            })
-            
-        else:
-            return HttpResponseRedirect('/')
+        return render(request, self.template_name, context={
+            'created_applications': CreatedStaffApplication.objects.all()
+        })
         
         
 class AllAppsSubmit(TemplateView):
@@ -57,9 +53,6 @@ class AllAppsSubmit(TemplateView):
             
         except ModuleNotFoundError:
             pass
-        
-        if request.headers.get('HX-Request') != "true":
-                return HttpResponseRedirect('/')
             
         form_data = request.POST
         if form_data['99342193074109'] != '':


### PR DESCRIPTION
This PR is overriding changes made in https://github.com/zediious/raptor-web/pull/204 in regards to HX-Request.

This middleware will check for the HX-Request header to be true

It will also check that `/api/` is within the request path, as this will always be the case for requests made by htmx. If it's missing, the response will be returned.

If both HX-Request is NOT true and `/api/` is present in the request path, the request will be redirected to `/404`