### PR TITLE
Convert login endpoints to use htmx

### DIFF
--- a/config/logging.py
+++ b/config/logging.py
@@ -100,6 +100,11 @@ LOGGING_DEFINITION = {
             'level': 'DEBUG',
             'propagate': False,
         },
+        'raptormc.hx_reroute_middleware': {
+            'handlers': ['console', 'log_file', 'mail_admins'],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
         'panel.routes': {
             'handlers': ['console', 'log_file', 'mail_admins'],
             'level': 'DEBUG',
@@ -116,6 +121,11 @@ LOGGING_DEFINITION = {
             'propagate': False,
         },
         'panel.forms': {
+            'handlers': ['console', 'log_file', 'mail_admins'],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
+        'panel.middleware': {
             'handlers': ['console', 'log_file', 'mail_admins'],
             'level': 'DEBUG',
             'propagate': False,

--- a/raptorWeb/authprofiles/forms.py
+++ b/raptorWeb/authprofiles/forms.py
@@ -140,13 +140,13 @@ class UserLoginForm(forms.Form):
             queried_user: RaptorUser = RaptorUser.objects.get(username=username)
             
             if queried_user.is_discord_user == True:
-                raise forms.ValidationError("The entered Password was incorrect")
+                raise forms.ValidationError("Account does not exist")
 
             if authenticate(username=username, password=password) == None:
-                raise forms.ValidationError("The entered Password was incorrect")
+                raise forms.ValidationError("Account does not exist")
 
         except RaptorUser.DoesNotExist:
-            raise forms.ValidationError("The entered Password was incorrect")
+            raise forms.ValidationError("Account does not exist")
 
 class UserPasswordResetEmailForm(forms.Form):
     """

--- a/raptorWeb/panel/middleware.py
+++ b/raptorWeb/panel/middleware.py
@@ -1,7 +1,11 @@
 import json
+from logging import Logger, getLogger
+
 from django.utils.deprecation import MiddlewareMixin
 from django.http import HttpRequest, HttpResponse
 from django.contrib.messages import get_messages
+
+LOGGER: Logger = getLogger('panel.middleware')
 
 class PanelMessages(MiddlewareMixin):
 

--- a/raptorWeb/panel/middleware.py
+++ b/raptorWeb/panel/middleware.py
@@ -15,6 +15,10 @@ class PanelMessages(MiddlewareMixin):
         if "HX-Request" not in request.headers:
             return response
         
+        # Do not add messages on requests with NoToastNotification header
+        if request.headers.get('Notoastnotifications') == 'true':
+            return response
+        
         # Only get messages if request is to api endpoints
         if "api" not in request.path:
             return response

--- a/raptorWeb/raptormc/hx_reroute_middleware.py
+++ b/raptorWeb/raptormc/hx_reroute_middleware.py
@@ -1,7 +1,10 @@
-import json
+from logging import Logger, getLogger
+
 from django.utils.deprecation import MiddlewareMixin
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.contrib.messages import get_messages
+
+LOGGER: Logger = getLogger('raptormc.hx_reroute_middleware')
 
 class HxReroute(MiddlewareMixin):
 

--- a/raptorWeb/raptormc/hx_reroute_middleware.py
+++ b/raptorWeb/raptormc/hx_reroute_middleware.py
@@ -16,6 +16,7 @@ class HxReroute(MiddlewareMixin):
 
         # 404 the request if HX-Request is not true
         if ((request.headers.get('HX-Request') != "true") and ('/api/' in request.path)):
-            return HttpResponseRedirect('/404')
+            if ('/login' not in request.path) and ('/logout' not in request.path):
+                return HttpResponseRedirect('/404')
 
         return response

--- a/raptorWeb/raptormc/hx_reroute_middleware.py
+++ b/raptorWeb/raptormc/hx_reroute_middleware.py
@@ -10,6 +10,10 @@ class HxReroute(MiddlewareMixin):
 
     def process_response(self, request: HttpRequest, response: HttpResponse) -> HttpResponse:
 
+        # Skip processing if NoProcessHxRedirect header present
+        if (request.headers.get('Noprocesshxredirect') == "true"):
+            return response
+
         # 404 the request if HX-Request is not true
         if ((request.headers.get('HX-Request') != "true") and ('/api/' in request.path)):
             return HttpResponseRedirect('/404')

--- a/raptorWeb/templates/authprofiles/login.html
+++ b/raptorWeb/templates/authprofiles/login.html
@@ -3,8 +3,21 @@
 
 <link rel="stylesheet" href="{% static 'css/raptormc.css' %}">
 
-<div class="bg-dark text-white p-1 mt-0 mb-0 opacity-75 container">
-  <form action="{% url 'authprofiles:login' %}" method="POST">
+<div class="bg-dark text-white p-1 mt-0 mb-0 opacity-100 container">
+  {% if messages %}
+  <div class="messages d-flex flex-column gap-2 mb-2">
+      {% for message in messages %}
+      <div class="badge bg-warning text-black">
+          {{message}}
+      </div>
+      {% endfor %}
+  </div>
+  {% endif %}
+  <form hx-post="{% url 'authprofiles:login' %}"
+        hx-target="#user_login_form"
+        hx-swap="innerHTML"
+        hx-headers='{"NoToastNotifications": "true"}'
+  >
 
     {% csrf_token %}
     {% bootstrap_form login_form %}
@@ -15,10 +28,21 @@
     
     <a role="button" type="button"
        class="btn btn-discord mt-2 opacity-100"
-       href="{% url 'authprofiles:login_oauth' %}"
+       hx-get="{% url 'authprofiles:login_oauth' %}"
+       hx-headers='{"NoProcessHxRedirect": "true"}'
     >
       Login with Discord
     </a>
 
   </form>
 </div>
+
+{% if showDropdown %}
+
+<script>
+    if (!$('#profile_dropdown_toggle').hasClass("show")){
+      $('#profile_dropdown_toggle').dropdown('toggle');
+    }
+</script>
+
+{% endif %}

--- a/raptorWeb/templates/authprofiles/mfa_entry.html
+++ b/raptorWeb/templates/authprofiles/mfa_entry.html
@@ -1,70 +1,65 @@
-<!DOCTYPE html>
-
 {% load static %}
 {% load django_bootstrap5 %}
 
-<html lang="en" dir="ltr">
-
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>MFA Code Entry</title>
-    <script src="{% static 'javascript/src/dep/htmx.min.js' %}" hx-preserve="true"></script>
-    <script src="{% static 'javascript/src/dep/head-support.js' %}" hx-preserve="true"></script>
-    <link rel="stylesheet" href="{% static 'css/raptormc.css' %}">
-    <link rel="shortcut icon" type="image/x-icon"
-            href="{% if small_site_info.ico_image %}{{small_site_info.ico_image.url}}{% endif %}">
-</head>
-
-<body class='bg-dark'>
+<div class='bg-dark'>
 
     {% if mfa_complete %}
-
-        <script>
-            window.location.replace('/')
-        </script>
-
+        {% comment %} Rendering nothing if mfa is complete {% endcomment %}
     {% else %}
 
-        <main class="d-flex flex-column justify-content-center" id="signin_mfa_form_replace">
-            <div class="">
-                <header class="text-white p-4 mt-4">
-                    <h3 class="pageContent fw-bold text-center">
-                        Please enter your MFA code below.
-                    </h3>
-                </header>
-            </div>
+        {% if showDropdown %}
 
-            <div class='d-flex justify-content-center'>
-                {% if messages %}
-                <ul class="messages alert alert-warning m-3 p-3">
+        <script>
+            console.log('doing the ting')
+            if ($('#profile_dropdown_toggle').hasClass("show")){
+                
+            }
+            else {
+                console.log('toggling')
+                $('#profile_dropdown_toggle').dropdown('toggle');
+            }
+        </script>
+
+        {% endif %}
+
+    <main class="d-flex flex-column justify-content-center" id="signin_mfa_form_replace">
+        <div>
+            <header class="text-white m-1 p-1">
+                <p class="pageContent fw-bold text-center">
+                    Please enter your MFA code below.
+                </p>
+            </header>
+        </div>
+
+        <div>
+            {% if messages %}
+            <div class="messages d-flex flex-column gap-2 mb-2">
                 {% for message in messages %}
+                <div class="badge bg-warning text-black">
                     {{message}}
+                </div>
                 {% endfor %}
-                </ul>
-                {% endif %}
-                <form id="signin_mfa_form_alone" class="form p-3 text-white"
-                    hx-post="{% url 'authprofiles:mfa_login' %}"
-                    hx-swap="outerHTML"
-                    hx-target="#signin_mfa_form_replace"
-                >
-                    <div class='d-flex flex-column justify-content-center'>
-                        {% csrf_token %}
-                        {{ form.captcha }} 
-                        <div class="text-white">{% bootstrap_field signin_mfa_form.totp %}</div>
-                        <input name='username' type="hidden" value="{{otp_username}}">
-                        <button class="btn btn-success" type="submit">
-                            Submit Code
-                        </button>
-                    </div>
-
-                </form>
             </div>
-        </main>
+            {% endif %}
+            <form id="signin_mfa_form_alone" class="form p-1 text-white"
+                hx-post="{% url 'authprofiles:mfa_login' %}"
+                hx-swap="outerHTML"
+                hx-target="#signin_mfa_form_replace"
+                hx-headers='{"NoToastNotifications": "true"}'
+            >
+                <div class='d-flex flex-column justify-content-center'>
+                    {% csrf_token %}
+                    {{ form.captcha }} 
+                    <div class="text-white">{% bootstrap_field signin_mfa_form.totp %}</div>
+                    <input name='username' type="hidden" value="{{otp_username}}">
+                    <button class="btn btn-success" type="submit">
+                        Submit Code
+                    </button>
+                </div>
 
+            </form>
+        </div>
+    </main>
+    
     {% endif %}
-
-</body>
-
-<script src="{% static 'javascript/src/dep/bootstrap.bundle.min.js' %}"></script>
-<script src="{% static 'javascript/src/dep/jquery-3.6.1.min.js' %}"></script>
+</div>

--- a/raptorWeb/templates/authprofiles/profile_dropdown_noauth.html
+++ b/raptorWeb/templates/authprofiles/profile_dropdown_noauth.html
@@ -23,7 +23,8 @@
                     <section>
                         <div class="p-3 container">
                         <a role="button"
-                           href="{% url 'authprofiles:login_oauth' %}"
+                           hx-get="{% url 'authprofiles:login_oauth' %}"
+                           hx-headers='{"NoProcessHxRedirect": "true"}'
                            class="btn btn-discord w-100"
                         >
                             Register with Discord
@@ -66,16 +67,6 @@
                             After clicking "Send Reset Link", wait for confirmation message to appear.
                         </p>
                     </header>
-
-                    <section>
-                        {% if messages %}
-                        <ul class="messages alert alert-warning">
-                        {% for message in messages %}
-                            {{message}}
-                        {% endfor %}
-                        </ul>
-                        {% endif %}
-                    </section>
                     
                     <section>
                         <div class="bg-dark p-3 opacity-75 container">
@@ -95,7 +86,7 @@
 </div>
 <div class="float-end">
     <div class="dropstart">
-        <button class="btn dropdown-toggle d-flex" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+        <button id="profile_dropdown_toggle" class="btn dropdown-toggle d-flex" type="button" data-bs-toggle="dropdown" aria-expanded="false">
         <div id="profile_picture_box">
             <img id="noProfilePicture" class="filter-white border border-secondary border-2 p-2 w-100" 
                  src="{% static 'image/no_user.svg' %}"
@@ -118,7 +109,7 @@
                  hx-get="{% url 'authprofiles:login' %}"
                  hx-trigger="load"
                  hx-target="#user_login_form"
-                 hx-swap="outerHTML">
+                 hx-swap="innerHTML">
             </div>
 
             <div class="p-1 mb-0 text-center">


### PR DESCRIPTION
Presently, login always refreshes the page. Failed logins also do so. MFA also opens a full new doc to enter the code.

Goal of this PR is to make login failures and MFA entry non-refreshing actions. Only finishing authentication should refresh the page.